### PR TITLE
feat(components):  components 추가

### DIFF
--- a/components/button.tsx
+++ b/components/button.tsx
@@ -1,0 +1,23 @@
+import { cls } from '../libs/utils';
+
+interface ButtonProps {
+  large?: boolean;
+  text: string;
+  [key: string]: any;
+}
+
+export default function Button({ large = false, onClick, text, ...rest }: ButtonProps) {
+  return (
+    <button
+      {...rest}
+      className={cls(
+        'w-full bg-orange-500 hover:bg-orange-600 text-white px-4',
+        'border border-transparent rounded-md shadow-sm font-medium',
+        'focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 focus:outline-none',
+        large ? 'py-3 text-base' : 'py-2 text-sm '
+      )}
+    >
+      {text}
+    </button>
+  );
+}

--- a/components/floating-button.tsx
+++ b/components/floating-button.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+import React from 'react';
+
+interface FloatingButton {
+  children: React.ReactNode;
+  href: string;
+}
+
+export default function FloatingButton({ children, href }: FloatingButton) {
+  return (
+    <Link
+      className='fixed flex items-center justify-center max-w-xl text-white transition-colors \n
+       bg-orange-400 border-0 border-transparent rounded-full shadow-xl cursor-pointer \n 
+       hover:bg-orange-500 aspect-square w-14 bottom-24'
+      href={href}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/components/input.tsx
+++ b/components/input.tsx
@@ -1,0 +1,53 @@
+interface InputProps {
+  label: string;
+  name: string;
+  kind?: 'text' | 'phone' | 'price';
+  [key: string]: any;
+}
+
+export default function Input({ label, name, kind = 'text', ...rest }: InputProps) {
+  return (
+    <div>
+      <label className='block mb-1 text-sm font-medium text-gray-700' htmlFor={name}>
+        {label}
+      </label>
+      {kind === 'text' ? (
+        <div>
+          <input
+            id={name}
+            {...rest}
+            className='w-full px-3 py-2 placeholder-gray-400 border border-gray-300 rounded-md \n
+             shadow-sm appearance-none focus:outline-none focus:ring-orange-500 focus:border-orange-500'
+          />
+        </div>
+      ) : null}
+      {kind === 'price' ? (
+        <div className='relative flex items-center rounded-md shadow-sm'>
+          <div className='absolute left-0 flex items-center justify-center pl-3 pointer-events-none'>
+            <span className='text-sm text-gray-500'>$</span>
+          </div>
+          <input
+            id={name}
+            {...rest}
+            className='w-full px-3 py-2 placeholder-gray-400 border border-gray-300 rounded-md shadow-sm appearance-none pl-7 focus:outline-none focus:ring-orange-500 focus:border-orange-500'
+          />
+          <div className='absolute right-0 flex items-center pr-3 pointer-events-none'>
+            <span className='text-gray-500'>KRW</span>
+          </div>
+        </div>
+      ) : null}
+      {kind === 'phone' ? (
+        <div className='flex rounded-md shadow-sm'>
+          <span className='flex items-center justify-center px-3 text-sm text-gray-500 border border-r-0 border-gray-300 select-none rounded-l-md bg-gray-50'>
+            +82
+          </span>
+          <input
+            id={name}
+            {...rest}
+            className='w-full px-3 py-2 placeholder-gray-400 border border-gray-300 rounded-md rounded-l-none shadow-sm appearance-none focus:outline-none focus:ring-orange-500 focus:border-orange-500'
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/item.tsx
+++ b/components/item.tsx
@@ -1,0 +1,69 @@
+import Link from 'next/link';
+
+interface ItemProps {
+  id: number;
+  title: string;
+  price: number;
+  comments: number;
+  hearts: number;
+}
+
+export default function Item({ id, title, price, comments, hearts }: ItemProps) {
+  return (
+    <Link href={`/items/${id}`} className='w-full '>
+      <div className='flex justify-between pb-4 border-b cursor-pointer'>
+        <div className='flex space-x-4'>
+          {/* 물건 사진 */}
+          <div className='w-20 h-20 bg-gray-400 rounded-md' />
+
+          {/* 제품명 및 가격 */}
+          <div className='flex flex-col pt-2'>
+            <h3 className='text-sm font-medium text-gray-900'>{title}</h3>
+            <span className='mt-1 font-medium text-gray-900'>{price}</span>
+          </div>
+        </div>
+
+        {/*  하트(관심) 및 채팅 이모티콘 */}
+        {/* 하트(관심) */}
+        <div className='flex items-end justify-end space-x-2'>
+          <div className='flex space-x-0.5 items-center text-sm  text-gray-600'>
+            <svg
+              className='w-4 h-4'
+              fill='none'
+              stroke='currentColor'
+              viewBox='0 0 24 24'
+              xmlns='http://www.w3.org/2000/svg'
+            >
+              <path
+                strokeLinecap='round'
+                strokeLinejoin='round'
+                strokeWidth='2'
+                d='M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z'
+              ></path>
+            </svg>
+            <span>{hearts}</span>
+          </div>
+
+          {/* 채팅 이모티콘 */}
+          <div className='flex space-x-0.5 items-center text-sm  text-gray-600'>
+            <svg
+              className='w-4 h-4'
+              fill='none'
+              stroke='currentColor'
+              viewBox='0 0 24 24'
+              xmlns='http://www.w3.org/2000/svg'
+            >
+              <path
+                strokeLinecap='round'
+                strokeLinejoin='round'
+                strokeWidth='2'
+                d='M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z'
+              ></path>
+            </svg>
+            <span>{comments}</span>
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { cls } from '../libs/utils';
+import { useRouter } from 'next/navigation';
+
+interface LayoutProps {
+  title?: string;
+  canGoBack?: boolean;
+  hasTabBar?: boolean;
+  children: React.ReactNode;
+}
+
+export default function Layout({ title, canGoBack, hasTabBar, children }: LayoutProps) {
+  const router = useRouter();
+  const onClick = () => {
+    router.back();
+  };
+  return (
+    <div>
+      <div
+        className={cls(
+          !canGoBack ? 'justify-center px-10' : 'px-2',
+          'bg-white w-full max-w-xl text-lg font-medium py-3 fixed text-gray-800 border-b top-0  flex items-center'
+        )}
+      >
+        {canGoBack ? (
+          <button onClick={onClick}>
+            <svg
+              xmlns='http://www.w3.org/2000/svg'
+              fill='none'
+              viewBox='0 0 24 24'
+              strokeWidth={1.5}
+              stroke='currentColor'
+              className='w-6 h-6'
+            >
+              <path
+                strokeLinecap='round'
+                strokeLinejoin='round'
+                d='M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18'
+              />
+            </svg>
+          </button>
+        ) : null}
+        {title ? <span>{title}</span> : null}
+      </div>
+      <div className={cls('pt-16', hasTabBar ? 'pb-10' : '')}>{children}</div>
+      {hasTabBar ? (
+        <nav
+          className='fixed bottom-0 flex items-center justify-between w-full max-w-xl \n
+         px-10 pt-3 pb-5 text-xs text-gray-700 bg-white border-t'
+        >
+          {/*  홈 */}
+          <Link href='/' className='flex flex-col items-center space-y-2'>
+            <svg
+              xmlns='http://www.w3.org/2000/svg'
+              fill='none'
+              viewBox='0 0 24 24'
+              strokeWidth={1.5}
+              stroke='currentColor'
+              className='w-6 h-6'
+            >
+              <path
+                strokeLinecap='round'
+                strokeLinejoin='round'
+                d='M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25'
+              />
+            </svg>
+
+            <span>홈</span>
+          </Link>
+          {/*  동네생활 */}
+          <Link href='/community' className='flex flex-col items-center space-y-2'>
+            <svg
+              xmlns='http://www.w3.org/2000/svg'
+              fill='none'
+              viewBox='0 0 24 24'
+              strokeWidth={1.5}
+              stroke='currentColor'
+              className='w-6 h-6'
+            >
+              <path
+                strokeLinecap='round'
+                strokeLinejoin='round'
+                d='M12 7.5h1.5m-1.5 3h1.5m-7.5 3h7.5m-7.5 3h7.5m3-9h3.375c.621 0 1.125.504 1.125 1.125V18a2.25 2.25 0 01-2.25 2.25M16.5 7.5V18a2.25 2.25 0 002.25 2.25M16.5 7.5V4.875c0-.621-.504-1.125-1.125-1.125H4.125C3.504 3.75 3 4.254 3 4.875V18a2.25 2.25 0 002.25 2.25h13.5M6 7.5h3v3H6v-3z'
+              />
+            </svg>
+            <span>동네생활</span>
+          </Link>
+          {/*  채팅 */}
+          <Link href='/chats' className='flex flex-col items-center space-y-2'>
+            <svg
+              xmlns='http://www.w3.org/2000/svg'
+              fill='none'
+              viewBox='0 0 24 24'
+              strokeWidth={1.5}
+              stroke='currentColor'
+              className='w-6 h-6'
+            >
+              <path
+                strokeLinecap='round'
+                strokeLinejoin='round'
+                d='M8.625 12a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H8.25m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H12m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 01-2.555-.337A5.972 5.972 0 015.41 20.97a5.969 5.969 0 01-.474-.065 4.48 4.48 0 00.978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25z'
+              />
+            </svg>
+            <span>채팅</span>
+          </Link>
+          {/*  라이브 */}
+          <Link href='/live' className='flex flex-col items-center space-y-2'>
+            <svg
+              xmlns='http://www.w3.org/2000/svg'
+              fill='none'
+              viewBox='0 0 24 24'
+              strokeWidth={1.5}
+              stroke='currentColor'
+              className='w-6 h-6'
+            >
+              <path
+                strokeLinecap='round'
+                d='M15.75 10.5l4.72-4.72a.75.75 0 011.28.53v11.38a.75.75 0 01-1.28.53l-4.72-4.72M4.5 18.75h9a2.25 2.25 0 002.25-2.25v-9a2.25 2.25 0 00-2.25-2.25h-9A2.25 2.25 0 002.25 7.5v9a2.25 2.25 0 002.25 2.25z'
+              />
+            </svg>
+
+            <span>라이브</span>
+          </Link>
+          {/*  나의 캐럿 */}
+          <Link href='/profile' className='flex flex-col items-center space-y-2'>
+            <svg
+              xmlns='http://www.w3.org/2000/svg'
+              fill='none'
+              viewBox='0 0 24 24'
+              strokeWidth={1.5}
+              stroke='currentColor'
+              className='w-6 h-6'
+            >
+              <path
+                strokeLinecap='round'
+                strokeLinejoin='round'
+                d='M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z'
+              />
+            </svg>
+
+            <span>나의 캐럿</span>
+          </Link>
+        </nav>
+      ) : null}
+    </div>
+  );
+}

--- a/components/message.tsx
+++ b/components/message.tsx
@@ -1,0 +1,23 @@
+import { cls } from '@/libs/utils';
+
+interface MessageProps {
+  message: string;
+  reversed?: boolean;
+  avatarUrl?: string;
+}
+
+export default function Message({ message, reversed, avatarUrl }: MessageProps) {
+  return (
+    <div
+      className={cls(
+        'flex items-start',
+        reversed ? 'flex-row-reverse space-x-reverse' : 'space-x-2'
+      )}
+    >
+      <div className='w-8 h-8 rounded-full bg-slate-400' />
+      <div className='w-1/2 p-2 text-sm text-gray-700 border border-gray-300 rounded-md'>
+        <p>{message}</p>
+      </div>
+    </div>
+  );
+}

--- a/components/textarea.tsx
+++ b/components/textarea.tsx
@@ -1,0 +1,25 @@
+interface TextArea {
+  label?: string;
+  name?: string;
+  rows?: number;
+  [key: string]: any;
+}
+
+export default function TextArea({ label, name, rows = 4, ...rest }: TextArea) {
+  return (
+    <div>
+      {label ? (
+        <label htmlFor={name} className='block mb-1 text-sm font-medium text-gray-700'>
+          {label}
+        </label>
+      ) : null}
+      <textarea
+        id={name}
+        className='w-full mt-1 border-gray-300 rounded-md shadow-sm \n 
+        focus:ring-orange-500 focus:border-orange-500 '
+        rows={rows}
+        {...rest}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
### components 기본적인 코딩

- # button.tsx

`middle`
<img width="591" alt="image" src="https://github.com/Ryan-Dia/carrot-market/assets/76567238/fcae22a6-59ba-41ac-a1e7-2e8b0cd79b49">
`large`
<img width="519" alt="image" src="https://github.com/Ryan-Dia/carrot-market/assets/76567238/58446ace-6c60-4bb5-ab78-a2a5b26e3f0a">   

   - 자주 사용하는 버튼 컴포넌트화
   - size : middle(default)  /  large

---

<br>

- # floatin-gutton.tsx
<img width="111" alt="image" src="https://github.com/Ryan-Dia/carrot-market/assets/76567238/41a1f11a-f0fb-469a-9d4c-b76eb7ecf476">    

  - 내부 모양 변경가능 ({...rest}로 처리하여 원하는 svg 넣을 수 있음)


---

<br>

- # input.tsx

     - 자주 사용하는 input 형식 컴포넌트화 
     - label도 포함 (option)
     - text / phone / price 
     - {...rest} 처리를 하여 더 다양한 타입 가능 


---

<br>

- # item.tsx
<img width="604" alt="image" src="https://github.com/Ryan-Dia/carrot-market/assets/76567238/08611cb6-74c7-4512-b114-5a7047324839">

- 추후 상품사진, 상품명, 가격, 관심수, 채팅개수를 변수로 받아 변경가능

---

<br>

- # layout.tsx

    - tabBar ( 현재 위치 표시 or backButton)
    - nav 

---

<br>

- # message.tsx
    - chat에 사용되는 메시지 및 말풍선
    - 추후 프로필사진 추가가능

---

<br>


- # textarea.tsx

    - 제품 설명, live 설명 등 설명이 필요한 곳에 사용
    - label (option)
    - textarea의 속성 rows (option)

<div>

-----

- close [component 추가 #1](https://github.com/Ryan-Dia/carrot-market/issues/1) 